### PR TITLE
Add support for custom base uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.1.0]
+
+### Added
+
+- Add support for a custom base uri, useful for using a mock server for testing/implementing the API.
+
 ## [2.0.2]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Disable:
 $oxxa->disableTestMode();
 ```
 
+#### Mock server
+
+When testing with a mock server, you will be able to modify the base URL of the API with:
+
+```php
+$oxxa->setBaseUri('http://localhost:8080');
+```
+
+This will return the Oxxa instance, so you can chain it with other methods.
+
 ### Exceptions
 
 In case of errors, the client throws the exception `OxxaException`. 

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -14,7 +14,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.0.2';
+    private const VERSION = '2.1.0';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -12,13 +12,13 @@ use Throwable;
 
 class Oxxa implements OxxaClient
 {
-    private const BASE_URI = 'https://api.oxxa.com/command.php';
-
     private const TIMEOUT = 180;
 
     private const VERSION = '2.0.2';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
+
+    private string $baseUri = 'https://api.oxxa.com/command.php';
 
     /**
      * @throws OxxaException
@@ -35,6 +35,13 @@ class Oxxa implements OxxaClient
         if (Str::length($this->password) === 0) {
             throw OxxaException::missingPassword();
         }
+    }
+
+    public function setBaseUri(string $baseUri): self
+    {
+        $this->baseUri = $baseUri;
+
+        return $this;
     }
 
     public function enabledTestMode(): self
@@ -75,7 +82,7 @@ class Oxxa implements OxxaClient
         // Perform the request and throw an exception when the request failed
         try {
             $response = $pendingRequest
-                ->baseUrl(self::BASE_URI)
+                ->baseUrl($this->baseUri)
                 ->get('', $parameters)
                 ->throw();
         } catch (Throwable $throwable) {


### PR DESCRIPTION
# Changes

### Added

- Add support for a custom base uri, useful for using a mock server for testing/implementing the API.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
