### PR TITLE
Fix converted property of the `UserTldListRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.1.1]
+
+### Fixed
+
+- The `converted` property of the `UserTldListRequest` should contain the valuta name instead of a boolean.
+
 ## [2.1.0]
 
 ### Added

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -14,7 +14,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.1.0';
+    private const VERSION = '2.1.1';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 

--- a/src/Requests/UserTldListRequest.php
+++ b/src/Requests/UserTldListRequest.php
@@ -9,7 +9,7 @@ class UserTldListRequest implements Request
 {
     public function __construct(
         public ?bool $withPrice = null,
-        public ?bool $converted = null,
+        public ?string $converted = null,
         public ?string $tld = null,
     ) {
     }


### PR DESCRIPTION
# Changes

### Fixed

- The `converted` property of the `UserTldListRequest` should contain the valuta name instead of a boolean.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
