### PR TITLE
Use the proper key for the handle when updating an identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.1.2]
+
+### Fixed
+
+- Use the proper key for the handle when updating an identity.
+
 ## [2.1.1]
 
 ### Fixed

--- a/src/Endpoints/IdentityEndpoint.php
+++ b/src/Endpoints/IdentityEndpoint.php
@@ -199,7 +199,7 @@ class IdentityEndpoint extends Endpoint implements EndpointContract
             ->request(array_merge(
                 [
                     'command' => 'identity_upd',
-                    'handle' => $handle,
+                    'identity' => $handle,
                 ],
                 $identity->toArray()
             ));

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -14,7 +14,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.1.1';
+    private const VERSION = '2.1.2';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 


### PR DESCRIPTION
# Changes

### Fixed

- Use the proper key for the handle when updating an identity.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
