### PR TITLE
The `autoRenew` property of the `Domain` model is now handled as a bo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.1.3]
+
+### Fixed
+
+- The `autoRenew` property of the `Domain` model is now handled as a boolean instead of the Y/N values.
+
 ## [2.1.2]
 
 ### Fixed

--- a/src/Endpoints/DomainEndpoint.php
+++ b/src/Endpoints/DomainEndpoint.php
@@ -121,7 +121,7 @@ class DomainEndpoint extends Endpoint implements EndpointContract
                 ? $detailsNode->filter('identity-reseller')->text()
                 : null,
             nameserverGroup: $detailsNode->filter('nsgroup')->text(),
-            autoRenew: $detailsNode->filter('autorenew')->text(),
+            autoRenew: Toggle::toBoolean($detailsNode->filter('autorenew')->text()),
             expireDate: DateTime::createFromFormat('d-m-Y', $detailsNode->filter('expire_date')->text())->setTime(0, 0),
             useTrustee: $detailsNode->filter('usetrustee')->count()
                 ? Toggle::toBoolean($detailsNode->filter('usetrustee')->text())

--- a/src/Models/Domain.php
+++ b/src/Models/Domain.php
@@ -23,7 +23,7 @@ class Domain implements Model
         public ?string $sld = null,
         public ?string $tld = null,
         public ?int $period = 1,
-        public ?string $autoRenew = 'N',
+        public ?bool $autoRenew = false,
         public ?DateTimeInterface $expireDate = null,
         public ?bool $lock = null,
         public ?bool $useTrustee = null,

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -14,7 +14,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.1.2';
+    private const VERSION = '2.1.3';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 


### PR DESCRIPTION
…olean instead of the Y/N values

# Changes

### Fixed

- The `autoRenew` property of the `Domain` model is now handled as a boolean instead of the Y/N values.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
