### PR TITLE
Use the proper status code for register and transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.2.1]
+
+### Fixed
+
+- Use the proper status code for determining if the register or transfer action was successful.
+
 ## [2.2.0]
 
 ### Added

--- a/src/Endpoints/DomainEndpoint.php
+++ b/src/Endpoints/DomainEndpoint.php
@@ -47,7 +47,7 @@ class DomainEndpoint extends Endpoint implements EndpointContract
      *
      * @throws OxxaException
      */
-    public function list(DomainListRequest $request = null): OxxaResult
+    public function list(?DomainListRequest $request = null): OxxaResult
     {
         $xml = $this
             ->client
@@ -408,7 +408,7 @@ class DomainEndpoint extends Endpoint implements EndpointContract
      *
      * @throws OxxaException
      */
-    public function updateNameservers(Domain $domain, bool $dnssecDelete = null): OxxaResult
+    public function updateNameservers(Domain $domain, ?bool $dnssecDelete = null): OxxaResult
     {
         if (is_null($domain->tld) || is_null($domain->sld)) {
             return new OxxaResult(

--- a/src/Endpoints/DomainEndpoint.php
+++ b/src/Endpoints/DomainEndpoint.php
@@ -186,7 +186,14 @@ class DomainEndpoint extends Endpoint implements EndpointContract
         $statusDescription = $this->getStatusDescription($xml);
 
         return new OxxaResult(
-            success: $statusCode === StatusCode::STATUS_DOMAIN_REGISTER_REQUESTED,
+            success: in_array(
+                $statusCode,
+                [
+                    StatusCode::STATUS_DOMAIN_REGISTERED,
+                    StatusCode::STATUS_DOMAIN_REGISTER_REQUESTED,
+                ],
+                true
+            ),
             message: $statusDescription,
             status: $statusCode,
         );
@@ -457,7 +464,16 @@ class DomainEndpoint extends Endpoint implements EndpointContract
         $statusDescription = $this->getStatusDescription($xml);
 
         return new OxxaResult(
-            success: $statusCode === StatusCode::STATUS_DOMAIN_TRANSFER_REQUESTED,
+            success: in_array(
+                $statusCode,
+                [
+                    StatusCode::STATUS_DOMAIN_TRANSFER_REQUESTED,
+                    StatusCode::STATUS_DOMAIN_TRANSFER_PENDING,
+                    StatusCode::STATUS_DOMAIN_TRANSFERRED,
+                    StatusCode::STATUS_DOMAIN_TRANSFERRED_ALTERNATIVE,
+                ],
+                true
+            ),
             message: $statusDescription,
             status: $statusCode,
         );

--- a/src/Endpoints/IdentityEndpoint.php
+++ b/src/Endpoints/IdentityEndpoint.php
@@ -19,7 +19,7 @@ class IdentityEndpoint extends Endpoint implements EndpointContract
      *
      * @throws OxxaException
      */
-    public function list(IdentityListRequest $request = null): OxxaResult
+    public function list(?IdentityListRequest $request = null): OxxaResult
     {
         $xml = $this
             ->client

--- a/src/Endpoints/NameserverGroupEndpoint.php
+++ b/src/Endpoints/NameserverGroupEndpoint.php
@@ -17,7 +17,7 @@ class NameserverGroupEndpoint extends Endpoint implements EndpointContract
      *
      * @throws OxxaException
      */
-    public function list(NameserverGroupListRequest $request = null): OxxaResult
+    public function list(?NameserverGroupListRequest $request = null): OxxaResult
     {
         $xml = $this
             ->client

--- a/src/Endpoints/UserTldEndpoint.php
+++ b/src/Endpoints/UserTldEndpoint.php
@@ -18,7 +18,7 @@ class UserTldEndpoint extends Endpoint implements EndpointContract
      *
      * @throws OxxaException
      */
-    public function list(UserTldListRequest $request = null): OxxaResult
+    public function list(?UserTldListRequest $request = null): OxxaResult
     {
         $xml = $this
             ->client

--- a/src/Enum/StatusCode.php
+++ b/src/Enum/StatusCode.php
@@ -4,7 +4,9 @@ namespace Cyberfusion\Oxxa\Enum;
 
 class StatusCode
 {
-    public const STATUS_DOMAIN_REGISTER_REQUESTED = 'XMLOK 1';
+    public const STATUS_DOMAIN_REGISTERED = 'XMLOK 1';
+
+    public const STATUS_DOMAIN_REGISTER_REQUESTED = 'XMLPEN 1';
 
     public const STATUS_DOMAIN_AUTORENEW_CHANGED = 'XMLOK 2';
 
@@ -44,6 +46,10 @@ class StatusCode
 
     public const STATUS_DOMAIN_TRANSFER_REQUESTED = 'XMLPEN 3';
 
+    public const STATUS_DOMAIN_TRANSFERRED = 'XMLOK 17';
+
+    public const STATUS_DOMAIN_TRANSFERRED_ALTERNATIVE = 'XMLOK 76';
+
     public const STATUS_DOMAIN_TRANSFER_PENDING = 'XMLPEN 4';
 
     public const STATUS_DOMAIN_DELETED = 'XMLPEN 11';
@@ -61,4 +67,6 @@ class StatusCode
     public const STATUS_DNSSEC_DELETED = 'XMLOK 81';
 
     public const STATUS_DOMAIN_NOT_IN_ADMINISTRATION = 'XMLERR 24';
+
+    public const STATUS_INSUFFICIENT_FUNDS = 'XMLERR 87';
 }

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -14,7 +14,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.2.0';
+    private const VERSION = '2.2.1';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 

--- a/src/Support/OxxaResult.php
+++ b/src/Support/OxxaResult.php
@@ -32,7 +32,7 @@ class OxxaResult
         return $this->status;
     }
 
-    public function getData(string $key = null): mixed
+    public function getData(?string $key = null): mixed
     {
         if (! is_null($key)) {
             return $this->data[$key] ?? null;


### PR DESCRIPTION
# Changes

### Fixed

- Use the proper status code for determining if the register or transfer action was successful.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
