### PR TITLE
Set the proper parameter when requiring the trustee service for domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.2.2]
+
+### Fixed
+
+- Set the proper parameter when requiring the trustee service for domains.
+
 ## [2.2.1]
 
 ### Fixed

--- a/src/Models/Domain.php
+++ b/src/Models/Domain.php
@@ -50,7 +50,7 @@ class Domain implements Model
             'period' => $this->period,
             'autorenew' => $this->autoRenew,
             'lock' => $this->lock,
-            'use_trustee' => $this->useTrustee,
+            'usetrustee' => $this->useTrustee,
             'premium_price' => $this->premiumPrice,
             'execution_at' => $this->executionAt,
             'trans_epp' => $this->transferCode,

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -14,7 +14,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.2.1';
+    private const VERSION = '2.2.2';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 


### PR DESCRIPTION
# Changes

### Fixed

- Set the proper parameter when requiring the trustee service for domains.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
