### PR TITLE
Add missing price for additional domains when retrieving SSL products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.4.1]
+
+### Fixed
+
+- Add missing price for additional domains when retrieving SSL products.
+
 ## [2.4.0]
 
 ### Added

--- a/src/DataTransferObjects/Price.php
+++ b/src/DataTransferObjects/Price.php
@@ -7,6 +7,7 @@ class Price
     public function __construct(
         public int $period,
         public float $price,
+        public ?float $priceAdditional = null,
     ) {
     }
 }

--- a/src/Endpoints/ProductEndpoint.php
+++ b/src/Endpoints/ProductEndpoint.php
@@ -37,9 +37,14 @@ class ProductEndpoint extends Endpoint implements EndpointContract
                     $sslNode
                         ->filter('pricing > period')
                         ->each(function (Crawler $periodNode) use (&$pricing) {
+                            $priceExtraDomainNode = $periodNode->filter('price_extra_domain');
+
                             $pricing[] = new Price(
                                 period: (int) $periodNode->attr('months'),
                                 price: (float) $periodNode->filter('price')->text(),
+                                priceAdditional: $priceExtraDomainNode->count() && $priceExtraDomainNode->text() !== ''
+                                    ? (float) $periodNode->filter('price_extra_domain')->text()
+                                    : null,
                             );
                         });
                 }

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -14,7 +14,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.4.0';
+    private const VERSION = '2.4.1';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 


### PR DESCRIPTION
# Changes

### Fixed

- Add missing price for additional domains when retrieving SSL products.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
