### PR TITLE
Not all TLD's will return the EPP code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.6.1]
+
+### Fixed
+
+- Not all TLD's will return the EPP code.
+
 ## [2.6.0]
 
 ### Added

--- a/src/Endpoints/DomainEndpoint.php
+++ b/src/Endpoints/DomainEndpoint.php
@@ -258,7 +258,9 @@ class DomainEndpoint extends Endpoint implements EndpointContract
             success: $statusCode === StatusCode::STATUS_DOMAIN_TOKEN_SENT,
             message: $statusDescription,
             data: [
-                'epp' => $xml->filter('channel > order > details')->text(),
+                'epp' => $xml->filter('channel > order > details')->count()
+                    ? $xml->filter('channel > order > details')->text()
+                    : null,
             ],
             status: $statusCode,
         );

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -15,7 +15,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.6.0';
+    private const VERSION = '2.6.1';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 


### PR DESCRIPTION
# Changes

### Fixed

- Not all TLD's will return the EPP code.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
