### PR TITLE
🐛 Fixed date format for several properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.6.2]
+
+### Fixed
+
+- Fixed date format for the `execution_at` property of the Domain model.
+- Fixed date format for the `datebirth` and `idcarddate` property of the Identity model.
+
 ## [2.6.1]
 
 ### Fixed

--- a/pint.json
+++ b/pint.json
@@ -2,6 +2,7 @@
     "preset": "laravel",
     "rules": {
         "array_indentation": false,
-        "phpdoc_align": false
+        "phpdoc_align": false,
+        "single_line_empty_body": false
     }
 }

--- a/src/Models/Domain.php
+++ b/src/Models/Domain.php
@@ -52,7 +52,9 @@ class Domain implements Model
             'lock' => $this->lock,
             'usetrustee' => $this->useTrustee,
             'premium_price' => $this->premiumPrice,
-            'execution_at' => $this->executionAt,
+            'execution_at' => $this
+                ->executionAt
+                ?->format('d-m-Y'),
             'trans_epp' => $this->transferCode,
             'dnssec_delete' => $this->dnssecDelete,
         ]);

--- a/src/Models/Identity.php
+++ b/src/Models/Identity.php
@@ -87,7 +87,9 @@ class Identity implements Model
             'tel' => $this->tel,
             'fax' => $this->fax,
             'email' => $this->email,
-            'datebirth' => $this->dateBirth,
+            'datebirth' => $this
+                ->dateBirth
+                ?->format('d-m-Y'),
             'placebirth' => $this->placeBirth,
             'countrybirth' => $this->countryBirth,
             'postalbirth' => $this->postalBirth,
@@ -96,7 +98,9 @@ class Identity implements Model
             'vatnumber' => $this->vatNumber,
             'tmnumber' => $this->trademarkNumber,
             'tmcountry' => $this->trademarkCountry,
-            'idcarddate' => $this->idCardDate,
+            'idcarddate' => $this
+                ->idCardDate
+                ?->format('d-m-Y'),
             'idcardissuer' => $this->idCardIssuer,
             'xxxmemberid' => $this->xxxMemberId,
             'xxxpassword' => $this->xxxPassword,

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -15,7 +15,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.6.1';
+    private const VERSION = '2.6.2';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 

--- a/tests/Unit/DomainTest.php
+++ b/tests/Unit/DomainTest.php
@@ -141,7 +141,7 @@ class DomainTest extends TestCase
                 Arr::get($request->data(), 'nsgroup') === 'ABCD123456' &&
                 Arr::get($request->data(), 'dnstemplate') === 'ABCD123456' &&
                 Arr::get($request->data(), 'lock') === 'Y' &&
-                Arr::get($request->data(), 'execution_at') === '2020-01-01' &&
+                Arr::get($request->data(), 'execution_at') === '01-01-2020' &&
                 Arr::get($request->data(), 'test') === null;
         });
     }
@@ -180,7 +180,7 @@ class DomainTest extends TestCase
                 Arr::get($request->data(), 'nsgroup') === 'ABCD123456' &&
                 Arr::get($request->data(), 'dnstemplate') === 'ABCD123456' &&
                 Arr::get($request->data(), 'lock') === 'Y' &&
-                Arr::get($request->data(), 'execution_at') === '2020-01-01' &&
+                Arr::get($request->data(), 'execution_at') === '01-01-2020' &&
                 Arr::get($request->data(), 'test') === null;
         });
     }


### PR DESCRIPTION
# Changes

### Fixed

- Fixed date format for the `execution_at` property of the Domain model.
- Fixed date format for the `datebirth` and `idcarddate` property of the Identity model.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
