### PR TITLE
Properly set lock value when retrieving a single domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.8.1]
+
+### Fixed
+
+- Properly set lock value when retrieving a single domain.
+
 ## [2.8.0]
 
 ### Added

--- a/src/Endpoints/DomainEndpoint.php
+++ b/src/Endpoints/DomainEndpoint.php
@@ -136,6 +136,9 @@ class DomainEndpoint extends Endpoint implements EndpointContract
                 ? Toggle::toBoolean($detailsNode->filter('usetrustee')->text())
                 : null,
             dnsSec: Toggle::toBoolean($detailsNode->filter('dnssec')->text()),
+            lock: $detailsNode->filter('lock')->count()
+                ? Toggle::toBoolean($detailsNode->filter('lock')->text())
+                : null,
         );
 
         return new OxxaResult(

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -15,7 +15,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.8.0';
+    private const VERSION = '2.8.1';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 


### PR DESCRIPTION
# Changes

### Fixed

- Properly set lock value when retrieving a single domain.

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
