### PR TITLE
Add error code for when the EPP code has been requested too many times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Please note this changelog affects 
 this package and not the Oxxa API.
 
+## [2.10.0]
+
+### Added
+
+- Add error code for when the EPP code has been requested too many times (i.e. for the .be TLD).
+
 ## [2.9.0]
 
 ### Added

--- a/src/Enum/StatusCode.php
+++ b/src/Enum/StatusCode.php
@@ -99,4 +99,6 @@ class StatusCode
     public const STATUS_INSUFFICIENT_FUNDS = 'XMLERR 87';
 
     public const STATUS_HELPDESK_NEEDED = 'XMLERR 184';
+
+    public const STATUS_EPP_REQUESTED_TOO_MANY_TIMES = 'XMLERR 263';
 }

--- a/src/Oxxa.php
+++ b/src/Oxxa.php
@@ -15,7 +15,7 @@ class Oxxa implements OxxaClient
 {
     private const TIMEOUT = 180;
 
-    private const VERSION = '2.9.0';
+    private const VERSION = '2.10.0';
 
     private const USER_AGENT = 'oxxa-api-client/'.self::VERSION;
 


### PR DESCRIPTION
# Changes

### Added

- Add error code for when the EPP code has been requested too many times (i.e. for the .be TLD).

# Checks

- [x] The version constant is updated in `Oxxa.php`
- [x] The changelog is updated
